### PR TITLE
Improved PhraseTranslator

### DIFF
--- a/Acme/YourBundle/Translation/PhraseTranslator.php
+++ b/Acme/YourBundle/Translation/PhraseTranslator.php
@@ -7,23 +7,37 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 class PhraseTranslator extends BaseTranslator
 {
     
+    /**
+     * {@inheritdoc}
+     */
     public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
     {
-        $prefix = "{{__phrase_";
-        $suffix = "__}}";
-
-        if (!isset($locale)) {
-            $locale = $this->getLocale();
-        }
-
-        if (!isset($this->catalogues[$locale])) {
-            $this->loadCatalogue($locale);
-        }
-
-        if ($domain == 'routes') {
-            return strtr($this->catalogues[$locale]->get((string) $id, $domain), $parameters);
-        } else {
-            return $prefix.$id.$suffix;
-        }
+        return parent::trans($this->transformId($id, $domain), $parameters, $domain, $locale);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
+    {
+        return parent::transChoice($this->transformId($id, $domain), $number, $parameters, $domain, $locale);
+    }
+
+    /**
+     * Converts the Id to a PhraseApp-compatible Id
+     * Skips the `routes` domain as per documentation
+     *
+     * @param int $id
+     * @param int $domain
+     * @return string
+     */
+    protected function transformId($id, $domain)
+    {
+        if ($domain == 'routes') {
+            return $id;
+        }
+
+        return "{{__phrase_" . $id . "__}}";
+    }
+    
 }


### PR DESCRIPTION
In order to avoid problems down the road I improved the implementation of the Phrase Translator, this is what you should recommend to your users as it follows better OO practices.
- implemented support for both `trans` and `transChoice`
- removed duplicated code from BaseTranslator and made the translator act only on the ID as needed, reducing the chances of changes upstream not showing up locally.

I'm also working on a proper Symfony Bundle to implement all you describe, once its ready i'll share in case its interesting for you.
